### PR TITLE
Add HA and read & write expectations from event stores

### DIFF
--- a/2019.08.09_expectations_for_an_event_store.md
+++ b/2019.08.09_expectations_for_an_event_store.md
@@ -19,6 +19,8 @@ What I expect from some system managing storage of streams of events, intended t
 - ability to have metadata on stream level even if the stream does not exists yet
 - ability to have metadata on events
 - idempotent writes (more on that later)
+- support for high-availability scenarios
+- support for at least write quorums and causally consistent, monotonic reads
 
 other functionalities are bonuses, some bonuses are evil
 


### PR DESCRIPTION
Update expectations from event stores to require support for high availability scenarios, and at minimum require quorum writes, and causally consistent monotonic reads.